### PR TITLE
Fix click badoption usage

### DIFF
--- a/click_config_file.py
+++ b/click_config_file.py
@@ -74,8 +74,11 @@ def configuration_option(*param_decls, **attrs):
         `provider(file_path, cmd_name)`. Default: `configobj_provider()`
 
     """
+    param_decls = param_decls or ('--config', )
+    option_name = param_decls[0]
 
     def decorator(f):
+
         def callback(cmd_name, config_file_name, saved_callback, provider, ctx,
                      param, value):
             # nonlocal cmd_name, config_file_name, saved_callback, provider
@@ -83,6 +86,8 @@ def configuration_option(*param_decls, **attrs):
                 ctx.default_map = {}
             if not cmd_name:
                 cmd_name = ctx.info_name
+
+
             default_value = os.path.join(
                 click.get_app_dir(cmd_name), config_file_name)
             param.default = default_value
@@ -91,7 +96,7 @@ def configuration_option(*param_decls, **attrs):
             try:
                 config = provider(value, cmd_name)
             except Exception as e:
-                raise click.BadOptionUsage(
+                raise click.BadOptionUsage(option_name,
                     "Error reading configuration file: {}".format(e), ctx)
             ctx.default_map.update(config)
             return saved_callback(ctx, param,
@@ -120,6 +125,6 @@ def configuration_option(*param_decls, **attrs):
         partial_callback = functools.partial(
             callback, cmd_name, config_file_name, saved_callback, provider)
         attrs['callback'] = partial_callback
-        return click.option(*(param_decls or ('--config', )), **attrs)(f)
+        return click.option(*param_decls, **attrs)(f)
 
     return decorator

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author='Philipp Hack',
     author_email='philipp.hack@gmail.com',
     url='http://github.com/phha/click_config_file',
-    version='0.4.2',
+    version='0.4.3',
     license='MIT',
     description='Configuration file support for click applications.',
     long_description=long_description,


### PR DESCRIPTION
click.BadOptionUsage [expects the name of the option as the first
argument](https://click.palletsprojects.com/en/7.x/api/?highlight=badoptionusage#click.BadOptionUsage) (which was not provided). E.g. if a configuration file was not
present, on click 7.0 this resulted in errors like the following:

    Error: <click.core.Context object at 0x10c6b9e80>

Instead, when using it as designed, the error message becomes
isgnificantly more helpful:

    Error: Error reading configuration file: [Errno 2] No such file or directory: 'abc.yam'

P.S. @phha By the way, I noticed your `v0.4.3` tag is ahead of `master` by 1 commit, so I branched off from the tag instead of from `master`.

P.P.S. I'm interested in adding a recipe for `click_config_file` on http://conda-forge.org. Would you be interested to become a maintainer of the recipe?