### PR TITLE
add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: python
+matrix:
+  include:
+  - python: 3.6
+    env:
+      TOXENV: py26
+  - python: 3.6
+    env:
+      TOXENV: py27
+  - python: 3.6
+    env:
+      TOXENV: py32
+  - python: 3.4
+    env:
+      TOXENV: py34
+  - python: 3.5
+    env:
+      TOXENV: py35
+  - python: 3.6
+    env:
+      TOXENV: py36
+  - python: 3.7
+    dist: xenial
+    env:
+      TOXENV: py37
+  - python: pypy
+    env:
+      TOXENV: pypy
+# pipenv incompatible with pypy3; uncomment for first 2019 release
+# https://github.com/pypa/pipenv/issues/3313
+#  - python: pypy3.5
+#    env:
+#      TOXENV: pypy3
+# jython not officially supported
+
+install: pip install --upgrade pip tox
+
+script:	tox

--- a/Pipfile
+++ b/Pipfile
@@ -19,3 +19,4 @@ tox = {extras = ["pytest"]}
 pytest = "*"
 readme-renderer = "*"
 twine = "*"
+funcsigs = "*"


### PR DESCRIPTION
this adds a travis CI configuration file which tests on

 * python 2.6
 * python 2.7
 * python 3.2
 * python 3.4
 * python 3.5
 * python 3.6
 * python 3.7
 * pypy

[Link to build](https://travis-ci.org/ltalirz/click_config_file/builds/522292350)

Tests on pyp3 are currently disabled due to pipenv being incompatible
with pypy3 ([fix has been already merged](https://github.com/pypa/pipenv/pull/3322) but no new pipenv release yet).

Tests on jython are not provided since it's not supported by travis out
of the box (I managed to add it but still ran in to this [1] error, so
stopped looking into it).

[1] https://github.com/msgpack/msgpack-python/issues/303