### PR TITLE
implement option with no default for config file

### DIFF
--- a/click_config_file.py
+++ b/click_config_file.py
@@ -129,7 +129,7 @@ def configuration_option_base(*param_decls, **attrs):
             partial_callback = functools.partial(
                 callback, cmd_name, config_file_name, saved_callback, provider)
             attrs['callback'] = partial_callback
-        
+
         return click.option(*param_decls, **attrs)(f)
 
     return decorator

--- a/click_config_file.py
+++ b/click_config_file.py
@@ -46,7 +46,7 @@ class configobj_provider:
         return config
 
 
-def configuration_option(*param_decls, **attrs):
+def configuration_option_base(*param_decls, **attrs):
     """
     Adds configuration file support to a click application.
 
@@ -106,7 +106,7 @@ def configuration_option(*param_decls, **attrs):
         attrs.setdefault('help', 'Read configuration from FILE.')
         attrs.setdefault('expose_value', False)
         cmd_name = attrs.pop('cmd_name', None)
-        config_file_name = attrs.pop('config_file_name', 'config')
+        config_file_name = attrs.pop('config_file_name', None)
         provider = attrs.pop('provider', configobj_provider())
         path_default_params = {
             'exists': False,
@@ -121,10 +121,17 @@ def configuration_option(*param_decls, **attrs):
             for k, v in path_default_params.items()
         }
         attrs['type'] = click.Path(**path_params)
-        saved_callback = attrs.pop('callback', None)
-        partial_callback = functools.partial(
-            callback, cmd_name, config_file_name, saved_callback, provider)
-        attrs['callback'] = partial_callback
+
+        if config_file_name is not None:
+            # Add callback only if config_file_name specified
+            saved_callback = attrs.pop('callback', None)
+            partial_callback = functools.partial(
+                callback, cmd_name, config_file_name, saved_callback, provider)
+            attrs['callback'] = partial_callback
+        
         return click.option(*param_decls, **attrs)(f)
 
     return decorator
+
+
+configuration_option = functools.partial(configuration_option_base, config_file_name='config')


### PR DESCRIPTION
This adds a `click_config_file.configuration_option_base` which does not
have a default value for the name of the configuration file and only
looks for a configuration file when the option is given explicitly.

Just an example of how #1 could be resolved without breaking changes.
Happy to make changes & add tests.

I didn't want to put travis in the same PR, but [here is a build with both](https://travis-ci.org/ltalirz/click_config_file/builds/522296473) (of course, tests would still need to be added for the new `_base` option)