### PR TITLE
support type=click.File

### DIFF
--- a/click_config_file.py
+++ b/click_config_file.py
@@ -154,7 +154,7 @@ def configuration_option(*param_decls, **attrs):
             k: attrs.pop(k, v)
             for k, v in path_default_params.items()
         }
-        attrs['type'] = click.Path(**path_params)
+        attrs['type'] = attrs.get('type', click.Path(**path_params))
         saved_callback = attrs.pop('callback', None)
         partial_callback = functools.partial(
             configuration_callback, cmd_name, option_name, config_file_name, saved_callback, provider, implicit)

--- a/tests/test_configuration_option_explicit.py
+++ b/tests/test_configuration_option_explicit.py
@@ -338,3 +338,22 @@ def test_argument_file(runner, cfgfile):
     result = runner.invoke(cli, ['--config', str(cfgfile)])
     assert not result.exception
     assert result.exit_code == 0
+
+def test_read_cfg_from_file(runner, cfgfile):
+    """Test returning config file handle directly.
+
+    Note: configobj.Configobj works both with file paths and file handles (so does the default configobj_provider).
+    """
+    @click.command()
+    @click.argument('arg')
+    @configuration_option(type=click.File(), implicit=False)
+    def cli(arg):
+        click.echo(arg)
+        assert arg == 'foo'
+
+    cfg = 'arg = "foo"'
+    cfgfile.write(cfg)
+    result = runner.invoke(cli, ['--config', str(cfgfile)])
+    assert not result.exception, result.exception
+    assert result.exit_code == 0
+


### PR DESCRIPTION
fix #18

Let `configuration_option` respect the option `type` specified by the
user instead of enforcing `click.Path`.

This enables working with file handles, so that configuration providers
only need to `handle.read()` the files.
This can be useful in particular for reading configuration files
directly from URLs (which are not supported by `click.Path`), 
opening file handles via `urllib.request.urlopen`.