### PR TITLE
Raise `click.BadParameter` if config contains unknown keys

### DIFF
--- a/click_config_file.py
+++ b/click_config_file.py
@@ -90,6 +90,19 @@ def configuration_callback(cmd_name, option_name, config_file_name,
         except Exception as e:
             raise click.BadOptionUsage(option_name,
                 "Error reading configuration file: {}".format(e), ctx)
+
+        valid_params = [
+            p.name for p in ctx.command.params if p.name != option_name
+        ]
+        specified_params = list(config.keys())
+        unknown_params = set(specified_params).difference(set(valid_params))
+
+        if unknown_params:
+            raise click.BadParameter(
+                f'Invalid configuration file, the following keys are not '
+                f'supported: {unknown_params}', ctx, param
+            )
+
         ctx.default_map.update(config)
 
     return saved_callback(ctx, param, value) if saved_callback else value


### PR DESCRIPTION
Fixes #11 

Before, any keys in the configuration file that did not match any parameters of the command would be silently ignored. This could lead to confusion with users if they accidentally mistyped a parameter in the configuration file.

Here, the `configuration_callback` method is updated to cross-reference the keys in the configuration file with the names of the command's parameters. If any keys are not recognized a `click.BadParameter` is raised indicating the unrecognized keys.